### PR TITLE
adding Dockerfile to create container with node-red and this node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+#FROM resin/amd64-debian:jessie
+FROM resin/rpi-raspbian:jessie
+
+#RUN apt-get clean && apt-get update && apt-get install -y \
+#  npm \
+#  nodejs-legacy  \
+#  build-essential
+
+# node-red
+# RUN sudo npm install -g --unsafe-perm node-red
+
+RUN apt-get clean && apt-get update && apt-get install -y \
+  nodered
+
+RUN apt-get clean && apt-get update && apt-get install -y \
+  npm 
+
+EXPOSE 1880
+
+COPY . /root/agile-node-red-node
+
+RUN cd /root && mkdir -p .node-red && cd .node-red && npm install /root/agile-node-red-node
+
+CMD node-red


### PR DESCRIPTION
I think at the moment we can keep the Dockerfile here, together with the node sources.

The generated container is ARM, but runs automatically on AMD64 through QEMU. Later we might
want a native version as well ...
